### PR TITLE
fix: ime mode delete bad case workaround

### DIFF
--- a/packages/apps/board/src/components/board/OptionsModal.vue
+++ b/packages/apps/board/src/components/board/OptionsModal.vue
@@ -61,6 +61,22 @@ function orgOnSelect(selectedItems: Array<SelectOptionItem>, lastSelectItem: Sel
   orgLastSelectItem.value = lastSelectItem;
 }
 
+const isComposing = ref(false);
+
+function onCompositionStart() {
+  isComposing.value = true;
+}
+
+function onCompositionEnd() {
+  isComposing.value = false;
+}
+
+function onDelete(event: Event) {
+  if (isComposing.value) {
+    event.stopPropagation();
+  }
+}
+
 const teamsOptions = computed(() => {
   const res = rank.value.originTeams.map((t) => {
     return {
@@ -130,6 +146,9 @@ function onConfirm() {
             :options="orgOptions"
             :selected-options="orgSelectedItems"
             @select="orgOnSelect"
+            @compositionstart="onCompositionStart"
+            @compositionend="onCompositionEnd"
+            @keydown.delete.capture="onDelete"
           />
         </div>
       </div>


### PR DESCRIPTION
It seems that upstream repo do not consider about ime mode. https://github.com/moreta/vue-search-select/blob/main/libs/components/MultiSelect.vue#L175

So when the searchText is empty and in ime mode, the delete key will accidentally remove the item.

Before:

https://github.com/xcpcio/xcpcio/assets/24316656/c015b2fc-548f-4d64-ae82-a93ed023af20

After:

https://github.com/xcpcio/xcpcio/assets/24316656/991f686e-6b30-4a96-940e-f596a8a09779

