### PR TITLE
feat: extract filter functionality into separate FilterModal component

### DIFF
--- a/packages/apps/board/locales/en.yml
+++ b/packages/apps/board/locales/en.yml
@@ -30,6 +30,7 @@ type_menu:
   balloon: Balloon
   export: Export
   resolver: Resolver
+  filter: Filter
   options: Options
   awards: Awards
   utility: Utility

--- a/packages/apps/board/locales/zh-CN.yml
+++ b/packages/apps/board/locales/zh-CN.yml
@@ -30,6 +30,7 @@ type_menu:
   balloon: 气球
   export: 导出
   resolver: 滚榜
+  filter: 筛选
   options: 选项
   awards: 奖项
   utility: 工具

--- a/packages/apps/board/src/components.d.ts
+++ b/packages/apps/board/src/components.d.ts
@@ -25,6 +25,8 @@ declare module 'vue' {
     CustomResolver: typeof import('./components/CustomResolver.vue')['default']
     DataSourceInput: typeof import('./components/DataSourceInput.vue')['default']
     Export: typeof import('./components/board/Export.vue')['default']
+    FilterModal: typeof import('./components/board/FilterModal.vue')['default']
+    FilterModel: typeof import('./components/board/FilterModel.vue')['default']
     Footer: typeof import('./components/Footer.vue')['default']
     GiantsOptions: typeof import('./components/battle-of-giants/GiantsOptions.vue')['default']
     GiantsScoreBoard: typeof import('./components/battle-of-giants/GiantsScoreBoard.vue')['default']

--- a/packages/apps/board/src/components/board/FilterModal.vue
+++ b/packages/apps/board/src/components/board/FilterModal.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import type { Rank, RankOptions, SelectOptionItem } from "@xcpcio/core";
+import _ from "lodash";
+import { MultiSelect } from "vue-search-select";
+
+const props = defineProps<{
+  isHidden: boolean;
+  rank: Rank;
+  rankOptions: RankOptions;
+}>();
+
+const emit = defineEmits([
+  "update:isHidden",
+  "update:rankOptions",
+]);
+
+const beforeRankOptions = _.cloneDeep(props.rankOptions);
+
+const { t } = useI18n();
+
+const isHidden = computed({
+  get() {
+    return props.isHidden;
+  },
+  set(value) {
+    emit("update:isHidden", value);
+  },
+});
+
+const rankOptions = computed({
+  get() {
+    return props.rankOptions;
+  },
+  set(value) {
+    emit("update:rankOptions", value);
+  },
+});
+
+const title = computed(() => {
+  return t("type_menu.filter");
+});
+
+const rank = computed(() => props.rank);
+
+const isComposing = ref(false);
+
+function onCompositionStart() {
+  isComposing.value = true;
+}
+
+function onCompositionEnd() {
+  isComposing.value = false;
+}
+
+function onDelete(event: Event) {
+  if (isComposing.value) {
+    event.stopPropagation();
+  }
+}
+
+const orgOptions = computed(() => {
+  const res = rank.value.organizations.map((o) => {
+    return {
+      value: o,
+      text: o,
+    };
+  });
+
+  return res;
+});
+
+const orgSelectedItems = ref<Array<SelectOptionItem>>(rankOptions.value.filterOrganizations);
+function orgOnSelect(selectedItems: Array<SelectOptionItem>, _lastSelectItem: SelectOptionItem) {
+  orgSelectedItems.value = selectedItems;
+  rankOptions.value.setFilterOrganizations(selectedItems);
+}
+
+const teamsOptions = computed(() => {
+  const res = rank.value.originTeams.map((t) => {
+    return {
+      value: t.id,
+      text: t.organization ? `${t.name} - ${t.organization}` : t.name,
+    };
+  });
+
+  return res;
+});
+
+const teamsSelectedItems = ref<Array<SelectOptionItem>>(rankOptions.value.filterTeams);
+function teamsOnSelect(selectedItems: Array<SelectOptionItem>, _lastSelectItem: SelectOptionItem) {
+  teamsSelectedItems.value = selectedItems;
+  rankOptions.value.setFilterTeams(selectedItems);
+}
+
+async function onCancel() {
+  rankOptions.value.setSelf(beforeRankOptions);
+  await nextTick();
+  isHidden.value = true;
+}
+
+const localStorageKeyForFilterOrganizations = getLocalStorageKeyForFilterOrganizations();
+const localStorageKeyForFilterTeams = getLocalStorageKeyForFilterTeams();
+
+function onConfirm() {
+  // can't use useStorage, maybe it's a bug
+  localStorage.setItem(localStorageKeyForFilterOrganizations, JSON.stringify(orgSelectedItems.value));
+  localStorage.setItem(localStorageKeyForFilterTeams, JSON.stringify(teamsSelectedItems.value));
+
+  isHidden.value = true;
+}
+</script>
+
+<template>
+  <Modal
+    v-model:is-hidden="isHidden"
+    :title="title"
+    width="w-200"
+    mt="mt-4"
+  >
+    <div
+      w-full
+      font-bold font-mono text-base
+      flex flex-col gap-4
+      items-center justify-center
+    >
+      <div
+        flex flex-col w-full
+      >
+        <div
+          grid grid-cols-6 gap-y-4
+        >
+          <div
+            v-if="rank.contest.organization"
+            flex items-center
+            text-sm
+          >
+            {{ rank.contest.organization }}:
+          </div>
+
+          <div
+            v-if="rank.contest.organization"
+            flex items-center
+            w-full
+            col-span-6
+          >
+            <MultiSelect
+              :options="orgOptions"
+              :selected-options="orgSelectedItems"
+              @select="orgOnSelect"
+              @compositionstart="onCompositionStart"
+              @compositionend="onCompositionEnd"
+              @keydown.delete.capture="onDelete"
+            />
+          </div>
+
+          <div
+            text-sm
+            flex items-center
+          >
+            Team:
+          </div>
+
+          <div
+            flex items-center
+            w-full
+            col-span-6
+          >
+            <MultiSelect
+              :options="teamsOptions"
+              :selected-options="teamsSelectedItems"
+              @select="teamsOnSelect"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div
+        w-full
+        flex flex-row-reverse items-center
+        gap-x-4
+      >
+        <button
+          type="submit"
+          class="text-white bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"
+          font-medium text-sm
+          rounded-md
+          @click="onConfirm"
+        >
+          {{ t("button.confirm") }}
+        </button>
+        <button
+          type="reset"
+          class="py-2.5 px-5 text-gray-900 focus:outline-none bg-white border border-gray-200 hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
+          font-medium text-sm
+          rounded-md
+          @click="onCancel"
+        >
+          {{ t("button.cancel") }}
+        </button>
+      </div>
+    </div>
+  </Modal>
+</template>

--- a/packages/apps/board/src/components/board/OptionsModal.vue
+++ b/packages/apps/board/src/components/board/OptionsModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import type { Rank, RankOptions, SelectOptionItem } from "@xcpcio/core";
+import type { Rank, RankOptions } from "@xcpcio/core";
 import _ from "lodash";
-import { MultiSelect } from "vue-search-select";
 
 const props = defineProps<{
   isHidden: boolean;
@@ -43,22 +42,6 @@ const title = computed(() => {
   return t("type_menu.options");
 });
 
-const isComposing = ref(false);
-
-function onCompositionStart() {
-  isComposing.value = true;
-}
-
-function onCompositionEnd() {
-  isComposing.value = false;
-}
-
-function onDelete(event: Event) {
-  if (isComposing.value) {
-    event.stopPropagation();
-  }
-}
-
 const orgOptions = computed(() => {
   const res = rank.value.organizations.map((o) => {
     return {
@@ -70,12 +53,6 @@ const orgOptions = computed(() => {
   return res;
 });
 
-const orgSelectedItems = ref<Array<SelectOptionItem>>(rankOptions.value.filterOrganizations);
-function orgOnSelect(selectedItems: Array<SelectOptionItem>, _lastSelectItem: SelectOptionItem) {
-  orgSelectedItems.value = selectedItems;
-  rankOptions.value.setFilterOrganizations(selectedItems);
-}
-
 const teamsOptions = computed(() => {
   const res = rank.value.originTeams.map((t) => {
     return {
@@ -86,12 +63,6 @@ const teamsOptions = computed(() => {
 
   return res;
 });
-
-const teamsSelectedItems = ref<Array<SelectOptionItem>>(rankOptions.value.filterTeams);
-function teamsOnSelect(selectedItems: Array<SelectOptionItem>, _lastSelectItem: SelectOptionItem) {
-  teamsSelectedItems.value = selectedItems;
-  rankOptions.value.setFilterTeams(selectedItems);
-}
 
 const routeQueryForBattleOfGiants = useRouteQueryForBattleOfGiants();
 function persistBattleOfGiants() {
@@ -117,16 +88,8 @@ async function onCancel() {
   isHidden.value = true;
 }
 
-const localStorageKeyForFilterOrganizations = getLocalStorageKeyForFilterOrganizations();
-const localStorageKeyForFilterTeams = getLocalStorageKeyForFilterTeams();
-
 function onConfirm() {
-  // can't use useStorage, maybe it's a bug
-  localStorage.setItem(localStorageKeyForFilterOrganizations, JSON.stringify(orgSelectedItems.value));
-  localStorage.setItem(localStorageKeyForFilterTeams, JSON.stringify(teamsSelectedItems.value));
-
   persistBattleOfGiants();
-
   isHidden.value = true;
 }
 </script>
@@ -145,59 +108,32 @@ function onConfirm() {
       items-center justify-center
     >
       <div
-        flex flex-col w-full
+        flex flex-col
+        w-full
       >
         <div
           flex
         >
-          Filter
+          Feature
         </div>
 
         <div
-          ml-8 mt-2
-          grid grid-cols-6 gap-y-4
+          ml-4 mt-2
         >
           <div
-            v-if="rank.contest.organization"
-            flex items-center
-            text-sm
+            flex flex-row
           >
-            {{ rank.contest.organization }}:
-          </div>
-
-          <div
-            v-if="rank.contest.organization"
-            flex items-center
-            w-full
-            col-span-5
-          >
-            <MultiSelect
-              :options="orgOptions"
-              :selected-options="orgSelectedItems"
-              @select="orgOnSelect"
-              @compositionstart="onCompositionStart"
-              @compositionend="onCompositionEnd"
-              @keydown.delete.capture="onDelete"
-            />
-          </div>
-
-          <div
-            text-sm
-            flex items-center
-          >
-            Team:
-          </div>
-
-          <div
-            flex items-center
-            w-full
-            col-span-5
-          >
-            <MultiSelect
-              :options="teamsOptions"
-              :selected-options="teamsSelectedItems"
-              @select="teamsOnSelect"
-            />
+            <TheCheckbox
+              v-model="rankOptions.enableAnimatedSubmissions"
+            >
+              <span
+                ml-3
+                text-sm font-medium
+                text-gray-900 dark:text-gray-300
+              >
+                Submission Queue
+              </span>
+            </TheCheckbox>
           </div>
         </div>
       </div>
@@ -279,37 +215,6 @@ function onConfirm() {
           :teams-options="teamsOptions"
           :giants="rankOptions.battleOfGiants.redTeam"
         />
-      </div>
-
-      <div
-        flex flex-col
-        w-full
-      >
-        <div
-          flex
-        >
-          Feature
-        </div>
-
-        <div
-          ml-4 mt-2
-        >
-          <div
-            flex flex-row
-          >
-            <TheCheckbox
-              v-model="rankOptions.enableAnimatedSubmissions"
-            >
-              <span
-                ml-3
-                text-sm font-medium
-                text-gray-900 dark:text-gray-300
-              >
-                Submission Queue
-              </span>
-            </TheCheckbox>
-          </div>
-        </div>
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- Extract filter functionality from OptionsModal into a new FilterModal component
- Improve code organization and user experience with separate filter modal
- Add keyboard shortcut support (Command+F/Ctrl+F) for quick filter access

## Changes Made
- **New FilterModal.vue**: Standalone modal for organization and team filtering
- **Updated OptionsModal.vue**: Removed filter code, now focuses on Battle of Giants and Feature settings
- **Enhanced Board.vue**: Added FilterModal integration with menu item and keyboard shortcut
- **i18n Updates**: Added translations for "Filter" menu item (English/Chinese)
- **Code Improvements**: Extracted `isUserTyping()` helper function to reduce duplication

## User Experience Improvements
- Separate filter and options modals for better UX organization
- Command+F/Ctrl+F keyboard shortcut to toggle FilterModal (standard UX pattern)
- Cleaner modal layouts without nested sections

## Test Plan
- [x] Verify FilterModal opens/closes via menu click
- [x] Test Command+F/Ctrl+F keyboard shortcut functionality
- [x] Confirm filter functionality works (organization/team filtering)
- [x] Validate OptionsModal still works for Battle of Giants settings
- [x] Check i18n translations display correctly in both languages

🤖 Generated with [Claude Code](https://claude.ai/code)