### PR TITLE
chore: add .ruff_cache/ to Python .gitignore

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 .pytest_cache/
+.ruff_cache/
 __pycache__/


### PR DESCRIPTION
## Summary
- Add .ruff_cache/ to Python .gitignore to exclude Ruff linter cache files from version control

## Test plan
- [x] Verify .gitignore syntax is correct
- [x] Confirm .ruff_cache/ directory is properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)