### PR TITLE
refactor: remove legacy group query param adaptation logic

### DIFF
--- a/packages/apps/board/src/components/board/SecondLevelMenu.vue
+++ b/packages/apps/board/src/components/board/SecondLevelMenu.vue
@@ -93,22 +93,6 @@ onMounted(() => {
       return;
     }
 
-    (() => {
-      // Adapt the previous group query param
-      for (const item of props.items) {
-        if (!item.titles) {
-          continue;
-        }
-
-        for (const [_k, v] of item.titles) {
-          if (currentItemFromRouteQuery.value === v) {
-            currentItemFromRouteQuery.value = item.keyword;
-            return;
-          }
-        }
-      }
-    })();
-
     currentItem.value = currentItemFromRouteQuery.value;
     if (props.onChange) {
       props.onChange(currentItemFromRouteQuery.value);


### PR DESCRIPTION
## Summary
- Remove outdated code that was adapting previous group query parameters in SecondLevelMenu component
- This legacy adaptation logic is no longer needed and can be safely removed

## Test plan
- [x] Verify SecondLevelMenu component still functions correctly
- [x] Check that group filtering works as expected
- [x] Ensure no regression in query parameter handling

🤖 Generated with [Claude Code](https://claude.ai/code)