### PR TITLE
fix: improve Docker NVM version format and SVG favicon MIME type

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/xcpcio
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NVM_DIR=/root/.nvm
 ENV PATH="/root/.local/bin:$PATH"
-ENV NVM_VERSION="0.40.3"
+ENV NVM_VERSION="v0.40.3"
 
 # Install system dependencies, uv, nvm, and build project
 RUN apt-get update && apt-get install -y \
@@ -31,6 +31,5 @@ RUN apt-get update && apt-get install -y \
 
 
 EXPOSE 3000
-
 ENTRYPOINT ["/app/xcpcio/docker/docker_entry.sh"]
 CMD ["primary"]

--- a/packages/apps/board/index.html
+++ b/packages/apps/board/index.html
@@ -19,7 +19,7 @@
     </script>
     <!-- End Google Tag Manager -->
 
-    <link rel="icon" href="/balloon-512x512.svg" />
+    <link rel="icon" href="/balloon-512x512.svg" type="image/svg+xml" />
     <link rel="mask-icon" href="/balloon-512x512.svg" color="#00aba9" />
     <link rel="apple-touch-icon" href="/balloon-192x192.png" />
     <meta name="msapplication-TileColor" content="#00aba9" />


### PR DESCRIPTION
## Summary
- Fix NVM version format in Dockerfile to use proper v prefix (`v0.40.3` instead of `0.40.3`)
- Add explicit MIME type (`image/svg+xml`) for SVG favicon in index.html
- Remove trailing whitespace in Dockerfile

## Test plan
- [x] Verify Dockerfile builds correctly with proper NVM version format
- [x] Confirm SVG favicon displays properly in browser with correct MIME type
- [x] Check that no functionality is broken by these minor improvements

🤖 Generated with [Claude Code](https://claude.ai/code)