### PR TITLE
fix: resolve pnpm install error in Docker non-TTY environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     && nvm use 24 \
     && nvm alias default 24 \
     && corepack enable pnpm \
-    && pnpm install \
+    && pnpm install --force \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && cd python && uv install \
     && cd ..


### PR DESCRIPTION
## Summary
- Add `--force` flag to `pnpm install` in Dockerfile to resolve ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY error
- This error occurs when pnpm tries to remove node_modules directory in non-interactive Docker environment

## Test plan
- [x] Build Docker image successfully without pnpm TTY errors
- [x] Verify pnpm install completes without interactive prompts
- [x] Confirm application builds and runs correctly in Docker container

🤖 Generated with [Claude Code](https://claude.ai/code)