### PR TITLE
fix: update Python dependency installation to use uv sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           username: ${{ secrets.ALIYUN_REGISTRY_USERNAME }}
           password: ${{ secrets.ALIYUN_REGISTRY_TOKEN }}
 
-      - name: Build and Push packages/app
+      - name: Build and Push
         uses: docker/build-push-action@v6
         env:
           image_name: xcpcio

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     && corepack enable pnpm \
     && pnpm install --force \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && cd python && uv install \
+    && cd python && uv sync \
     && cd ..
 
 


### PR DESCRIPTION
## Summary
- Update Dockerfile to use `uv sync` instead of `uv install` for proper dependency management
- Clean up GitHub workflow step name for better clarity

## Test plan
- [ ] Verify Docker build works with new uv sync command
- [ ] Test Python dependencies are properly installed in container
- [ ] Confirm workflow still functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)