### PR TITLE
fix: activate Python virtual environment in Docker entry script

### DIFF
--- a/docker/docker_entry.sh
+++ b/docker/docker_entry.sh
@@ -3,6 +3,9 @@
 # Load nvm if available
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
+# shellcheck disable=SC1091
+[ -s "/app/xcpcio/python/.venv/bin/activate" ] && source "/app/xcpcio/python/.venv/bin/activate"
+
 CUR_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 EXPORT_PATH="/app/export"


### PR DESCRIPTION
## Summary

- Add automatic activation of Python virtual environment in Docker entry script
- Ensures Python dependencies installed in the venv are accessible when running scripts in the containerized environment
- Uses shellcheck disable directive to suppress warning for dynamic source path

## Test plan

- [x] Verify Docker container starts correctly with the modified entry script
- [x] Test that Python scripts can access venv dependencies when available
- [x] Confirm no impact when venv is not present

🤖 Generated with [Claude Code](https://claude.ai/code)