### PR TITLE
feat: add access endpoint support and preserve provider name case

### DIFF
--- a/python/xcpcio/ccs/contest_archiver.py
+++ b/python/xcpcio/ccs/contest_archiver.py
@@ -59,6 +59,7 @@ class ContestArchiver:
 
     # Known endpoints that can be fetched
     KNOWN_ENDPOINTS = [
+        "access",
         "contests",
         "judgement-types",
         "languages",
@@ -79,6 +80,7 @@ class ContestArchiver:
     ]
 
     DOMJUDGE_KNOWN_ENDPOINTS = [
+        "access",
         "contests",
         "judgement-types",
         "languages",
@@ -294,7 +296,7 @@ class ContestArchiver:
         # Parse provider information
         if "provider" in data:
             provider: Dict = data.get("provider", {})
-            self._provider_name = provider.get("name", "").lower()
+            self._provider_name = provider.get("name", "")
 
             # Parse version string to semver.VersionInfo
             version_str: str = provider.get("version", "")


### PR DESCRIPTION
## Summary
- Add "access" endpoint to KNOWN_ENDPOINTS and DOMJUDGE_KNOWN_ENDPOINTS lists for better CCS API coverage
- Preserve original case of provider name by removing .lower() transformation

## Test plan
- [x] Verify access endpoint is now included in archiving process
- [x] Confirm provider name maintains original casing in archived data

🤖 Generated with [Claude Code](https://claude.ai/code)