### PR TITLE
fix: optimize Docker workflow setup order and QEMU configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,15 @@ jobs:
         run: |
           cp ./packages/apps/board/dist/index.html ./packages/apps/board/dist/404.html
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-
       - name: Available platforms
         run: echo ${{ steps.qemu.outputs.platforms }}
 
@@ -98,12 +100,6 @@ jobs:
           echo "Status:    ${{ steps.buildx.outputs.status }}"
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Move Docker Hub login step before QEMU setup for better authentication flow
- Remove redundant QEMU configuration parameters (image and platforms)
- Simplify workflow execution order for Docker multi-platform builds

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Confirm Docker multi-platform builds work correctly  
- [ ] Check that all container registries receive proper authentication

🤖 Generated with [Claude Code](https://claude.ai/code)