### PR TITLE
feat: add version support to CLI commands and update maintainers

### DIFF
--- a/python/app/contest_api_server.py
+++ b/python/app/contest_api_server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import click
 
+from xcpcio import __version__
 from xcpcio.ccs.api_server.server import ContestAPIServer
 
 
@@ -15,6 +16,7 @@ def setup_logging(level: str = "INFO"):
 
 
 @click.command()
+@click.version_option(__version__)
 @click.option(
     "--contest-dir",
     "-d",

--- a/python/cli/ccs_archiver_cli.py
+++ b/python/cli/ccs_archiver_cli.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import click
 
+from xcpcio import __version__
 from xcpcio.ccs.contest_archiver import APICredentials, ArchiveConfig, ContestArchiver
 
 
@@ -17,6 +18,7 @@ def setup_logging(level: str = "INFO"):
 
 
 @click.command()
+@click.version_option(__version__)
 @click.option("--base-url", required=True, help="Base URL of the CCS API (e.g., https://example.com/api)")
 @click.option("--contest-id", required=True, help="Contest ID to dump")
 @click.option(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,6 +3,10 @@ name = "xcpcio"
 description = "xcpcio python lib"
 readme = "README.md"
 authors = [ { name = "Dup4", email = "hi@dup4.com" } ]
+maintainers = [
+    { name = "Dup4", email = "hi@dup4.com" },
+    { name = "cubercsl", email = "hi@cubercsl.site" },
+]
 license = "MIT"
 keywords = [ "xcpcio" ]
 classifiers = [


### PR DESCRIPTION
## Summary
- Add `--version` option to contest API server CLI command
- Add `--version` option to CCS archiver CLI command  
- Update pyproject.toml with maintainers field including Dup4 and cubercsl

## Test plan
- [ ] Verify `--version` flag works on contest API server CLI
- [ ] Verify `--version` flag works on CCS archiver CLI
- [ ] Confirm maintainers are properly listed in package metadata

🤖 Generated with [Claude Code](https://claude.ai/code)