### PR TITLE
feat: add filtering support to judgements and runs endpoints

### DIFF
--- a/python/xcpcio/ccs/api_server/routes/judgements.py
+++ b/python/xcpcio/ccs/api_server/routes/judgements.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Query
 
 from ..dependencies import ContestServiceDep
 
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 )
 async def get_judgements(
     contest_id: str = Path(..., description="Contest identifier"),
+    submission_id: Optional[str] = Query(None, description="Filter judgements by submission ID"),
     service: ContestServiceDep = None,
 ) -> List[Dict[str, Any]]:
-    return service.get_judgements(contest_id)
+    return service.get_judgements(contest_id, submission_id)
 
 
 @router.get(

--- a/python/xcpcio/ccs/api_server/routes/runs.py
+++ b/python/xcpcio/ccs/api_server/routes/runs.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Query
 
 from ..dependencies import ContestServiceDep
 
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 )
 async def get_runs(
     contest_id: str = Path(..., description="Contest identifier"),
+    judgement_id: Optional[str] = Query(None, description="Filter runs by judgement ID"),
     service: ContestServiceDep = None,
 ) -> List[Dict[str, Any]]:
-    return service.get_runs(contest_id)
+    return service.get_runs(contest_id, judgement_id)
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- Add `submission_id` query parameter to `/judgements` endpoint for filtering judgements by specific submission
- Add `judgement_id` query parameter to `/runs` endpoint for filtering runs by specific judgement
- Implement efficient O(1) lookups using indexed dictionaries in ContestService
- Add proper 404 error handling for invalid submission/judgement IDs

## Test plan
- [ ] Test `/judgements` endpoint with valid `submission_id` parameter
- [ ] Test `/judgements` endpoint with invalid `submission_id` parameter (should return 404)
- [ ] Test `/runs` endpoint with valid `judgement_id` parameter  
- [ ] Test `/runs` endpoint with invalid `judgement_id` parameter (should return 404)
- [ ] Verify existing functionality still works without query parameters
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)