### PR TITLE
refactor: centralize file handling logic in CCS API service layer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -127,6 +127,7 @@
     "pinia",
     "pnpm",
     "prettierrc",
+    "problemset",
     "pytest",
     "shiki",
     "shikijs",

--- a/python/xcpcio/ccs/api_server/base/__init__.py
+++ b/python/xcpcio/ccs/api_server/base/__init__.py
@@ -1,0 +1,3 @@
+from . import types
+
+__all__ = [types]

--- a/python/xcpcio/ccs/api_server/base/types.py
+++ b/python/xcpcio/ccs/api_server/base/types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class FileAttr:
+    path: Path
+    media_type: str
+    name: str

--- a/python/xcpcio/ccs/api_server/routes/contests.py
+++ b/python/xcpcio/ccs/api_server/routes/contests.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Query
 from fastapi import Path as FastAPIPath
 from fastapi.responses import FileResponse, StreamingResponse
 
@@ -55,22 +54,8 @@ async def get_contest_banner(
     contest_id: str = FastAPIPath(..., description="Contest identifier"),
     service: ContestServiceDep = None,
 ) -> FileResponse:
-    service.validate_contest_id(contest_id)
-
-    expected_href = f"contests/{contest_id}/banner"
-
-    try:
-        banners = service.contest.get("banner", [])
-        for banner in banners:
-            href = banner["href"]
-            if href == expected_href:
-                filename = banner["filename"]
-                banner_file: Path = service.contest_package_dir / "contest" / filename
-                if banner_file.exists():
-                    mime_type = banner["mime"]
-                    return FileResponse(path=banner_file, media_type=mime_type, filename=filename)
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Banner not found. [contest_id={contest_id}] [err={e}]")
+    file_attr = service.get_contest_banner(contest_id)
+    return FileResponse(path=file_attr.path, media_type=file_attr.media_type, filename=file_attr.name)
 
 
 @router.get(
@@ -82,22 +67,8 @@ async def get_contest_problem_set(
     contest_id: str = FastAPIPath(..., description="Contest identifier"),
     service: ContestServiceDep = None,
 ) -> FileResponse:
-    service.validate_contest_id(contest_id)
-
-    expected_href = f"contests/{contest_id}/problemset"
-
-    try:
-        problem_set_list = service.contest.get("problemset", [])
-        for problem_set in problem_set_list:
-            href = problem_set["href"]
-            if href == expected_href:
-                filename = problem_set["filename"]
-                problem_set_file: Path = service.contest_package_dir / "contest" / filename
-                if problem_set_file.exists():
-                    mime_type = problem_set["mime"]
-                    return FileResponse(path=problem_set_file, media_type=mime_type, filename=filename)
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Problem set not found. [contest_id={contest_id}] [err={e}]")
+    file_attr = service.get_contest_problemset(contest_id)
+    return FileResponse(path=file_attr.path, media_type=file_attr.media_type, filename=file_attr.name)
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- Extract duplicate file lookup logic from route handlers into reusable `_get_file()` method in service layer
- Add `FileAttr` type to represent file metadata (path, media_type, name)
- Implement dedicated service methods for file operations: `get_contest_banner()`, `get_contest_problemset()`, `get_problem_statement()`, `get_team_photo()`, `get_organization_logo()`, `get_submission_file()`
- Simplify route handlers by delegating file operations to service layer
- Make `load_json_file()` and `load_ndjson_file()` private methods (prefixed with `_`)
- Improve error handling with consistent exception messages across all file endpoints

## Changes
- Removed ~180 lines of duplicate code from route handlers
- Added centralized file handling logic in `contest_service.py`
- Created `base/types.py` for shared type definitions
- All 6 file endpoints now use consistent logic through the service layer

🤖 Generated with [Claude Code](https://claude.ai/code)