### PR TITLE
fix: improve temp directory cleanup in ccs-archiver CLI

### DIFF
--- a/python/cli/ccs_archiver_cli.py
+++ b/python/cli/ccs_archiver_cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 import hashlib
 import logging
 import shutil
@@ -124,7 +125,14 @@ def main(
     output_str = str(output)
     is_archive = output_str.endswith((".zip", ".tar.gz", ".tar.zst"))
     archive_format = None
-    temp_dir = None
+    temp_dir: Optional[Path] = None
+
+    def cleanup_temp_dir():
+        if temp_dir and temp_dir.exists():
+            click.echo(f"Cleaning up temporary directory: {temp_dir}")
+            shutil.rmtree(temp_dir)
+
+    atexit.register(cleanup_temp_dir)
 
     if is_archive:
         if output_str.endswith(".zip"):
@@ -207,9 +215,6 @@ def main(
     except Exception as e:
         click.echo(click.style(f"Error during archive: {e}", fg="red"), err=True)
         raise click.ClickException(str(e))
-    finally:
-        if temp_dir and temp_dir.exists():
-            shutil.rmtree(temp_dir)
 
 
 if __name__ == "__main__":

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "tenacity>=8.0.0",
   "fastapi>=0.117.1",
   "uvicorn>=0.36.0",
+  "zstandard>=0.25.0",
 ]
 dynamic = ["version"]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1408,6 +1408,7 @@ dependencies = [
     { name = "semver" },
     { name = "tenacity" },
     { name = "uvicorn" },
+    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -1429,6 +1430,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "uvicorn", specifier = ">=0.36.0" },
+    { name = "zstandard", specifier = ">=0.25.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Improved temp directory cleanup reliability using `atexit` handler
- Added explicit type annotation for `temp_dir` variable  
- Added `zstandard` dependency for `.tar.zst` archive format support

## Test plan

- [ ] Verify archive creation with zip format works correctly
- [ ] Verify archive creation with tar.gz format works correctly
- [ ] Verify archive creation with tar.zst format works correctly
- [ ] Verify temp directory is cleaned up properly on normal exit
- [ ] Verify temp directory is cleaned up properly on error/interrupt

🤖 Generated with [Claude Code](https://claude.ai/code)