### PR TITLE
fix: improve IME input width for MultiSelect component

### DIFF
--- a/packages/apps/board/src/components.d.ts
+++ b/packages/apps/board/src/components.d.ts
@@ -33,6 +33,7 @@ declare module 'vue' {
     HeatMapTooltip: typeof import('./components/board/HeatMapTooltip.vue')['default']
     Modal: typeof import('./components/board/Modal.vue')['default']
     ModalMenu: typeof import('./components/board/ModalMenu.vue')['default']
+    MultiSelectEnhanced: typeof import('./components/common/MultiSelectEnhanced.vue')['default']
     NavBar: typeof import('./components/NavBar.vue')['default']
     OptionsModal: typeof import('./components/board/OptionsModal.vue')['default']
     ProblemBlock: typeof import('./components/board/ProblemBlock.vue')['default']

--- a/packages/apps/board/src/components/battle-of-giants/GiantsOptions.vue
+++ b/packages/apps/board/src/components/battle-of-giants/GiantsOptions.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Giants, Rank, SelectOptionItem } from "@xcpcio/core";
 import { GiantsType } from "@xcpcio/core";
-import { MultiSelect } from "vue-search-select";
 
 const props = defineProps<{
   rank: Rank;
@@ -109,7 +108,7 @@ const color = computed(() => {
         w-full
         col-span-5
       >
-        <MultiSelect
+        <MultiSelectEnhanced
           :options="orgOptions"
           :selected-options="orgSelectedItems"
           @select="orgOnSelect"
@@ -128,7 +127,7 @@ const color = computed(() => {
         w-full
         col-span-5
       >
-        <MultiSelect
+        <MultiSelectEnhanced
           :options="teamsOptions"
           :selected-options="teamsSelectedItems"
           @select="teamsOnSelect"

--- a/packages/apps/board/src/components/board/FilterModal.vue
+++ b/packages/apps/board/src/components/board/FilterModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Rank, RankOptions, SelectOptionItem } from "@xcpcio/core";
 import _ from "lodash";
-import { MultiSelect } from "vue-search-select";
 
 const props = defineProps<{
   isHidden: boolean;
@@ -41,22 +40,6 @@ const title = computed(() => {
 });
 
 const rank = computed(() => props.rank);
-
-const isComposing = ref(false);
-
-function onCompositionStart() {
-  isComposing.value = true;
-}
-
-function onCompositionEnd() {
-  isComposing.value = false;
-}
-
-function onDelete(event: Event) {
-  if (isComposing.value) {
-    event.stopPropagation();
-  }
-}
 
 const orgOptions = computed(() => {
   const res = rank.value.organizations.map((o) => {
@@ -143,13 +126,10 @@ function onConfirm() {
             w-full
             col-span-6
           >
-            <MultiSelect
+            <MultiSelectEnhanced
               :options="orgOptions"
               :selected-options="orgSelectedItems"
               @select="orgOnSelect"
-              @compositionstart="onCompositionStart"
-              @compositionend="onCompositionEnd"
-              @keydown.delete.capture="onDelete"
             />
           </div>
 
@@ -165,7 +145,7 @@ function onConfirm() {
             w-full
             col-span-6
           >
-            <MultiSelect
+            <MultiSelectEnhanced
               :options="teamsOptions"
               :selected-options="teamsSelectedItems"
               @select="teamsOnSelect"

--- a/packages/apps/board/src/components/board/SubmissionsTable.vue
+++ b/packages/apps/board/src/components/board/SubmissionsTable.vue
@@ -6,8 +6,6 @@ import { Pagination } from "@board/composables/pagination";
 import { Submission } from "@xcpcio/core";
 import { SubmissionStatusToString } from "@xcpcio/types";
 
-import { MultiSelect } from "vue-search-select";
-
 import "@board/styles/submission-status-filter.css";
 
 interface FilterOptions {
@@ -302,9 +300,9 @@ function closeVideoModal() {
           >
             <div
               v-if="rank.contest.organization && enableFilter?.organization"
-              w-48
+              w-64
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="orgOptions"
                 :selected-options="orgSelectedItems"
                 :placeholder="rank.contest.organization"
@@ -314,9 +312,9 @@ function closeVideoModal() {
 
             <div
               v-if="enableFilter?.team"
-              w-48
+              w-64
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="teamsOptions"
                 :selected-options="teamsSelectedItems"
                 placeholder="Team"
@@ -326,9 +324,9 @@ function closeVideoModal() {
 
             <div
               v-if="enableFilter?.status"
-              w-68
+              w-64
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="statusOptions"
                 :selected-options="statusSelectedItems"
                 placeholder="Status"
@@ -341,7 +339,7 @@ function closeVideoModal() {
               v-if="enableFilter?.language && languageOptions.length > 0"
               w-48
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="languageOptions"
                 :selected-options="languageSelectedItems"
                 placeholder="Language"

--- a/packages/apps/board/src/components/common/MultiSelectEnhanced.vue
+++ b/packages/apps/board/src/components/common/MultiSelectEnhanced.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { SelectOptionItem } from "@xcpcio/core";
+import { MultiSelect } from "vue-search-select";
+
+interface Props {
+  options: SelectOptionItem[];
+  selectedOptions: SelectOptionItem[];
+}
+
+interface Emits {
+  (e: "select", selectedItems: SelectOptionItem[], lastSelectItem: SelectOptionItem): void;
+}
+
+defineProps<Props>();
+const emit = defineEmits<Emits>();
+
+const isComposing = ref(false);
+
+function onCompositionStart() {
+  isComposing.value = true;
+}
+
+function onCompositionEnd() {
+  isComposing.value = false;
+}
+
+function onDelete(event: Event) {
+  if (isComposing.value) {
+    event.stopPropagation();
+  }
+}
+
+function onSelect(selectedItems: SelectOptionItem[], lastSelectItem: SelectOptionItem) {
+  emit("select", selectedItems, lastSelectItem);
+}
+</script>
+
+<template>
+  <MultiSelect
+    :class="{ 'is-composing': isComposing }"
+    :options="options"
+    :selected-options="selectedOptions"
+    @select="onSelect"
+    @compositionstart="onCompositionStart"
+    @compositionend="onCompositionEnd"
+    @keydown.delete.capture="onDelete"
+  />
+</template>

--- a/packages/apps/board/src/components/rating/RatingTable.vue
+++ b/packages/apps/board/src/components/rating/RatingTable.vue
@@ -3,8 +3,6 @@ import type { Rating, SelectOptionItem } from "@xcpcio/core";
 
 import { Pagination } from "@board/composables/pagination";
 
-import { MultiSelect } from "vue-search-select";
-
 interface FilterOptions {
   organizations: string[];
   members: string[];
@@ -157,7 +155,7 @@ const currentUsers = computed(() => {
             <div
               w-108
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="orgOptions"
                 :selected-options="orgSelectedItems"
                 placeholder="Organization"
@@ -168,7 +166,7 @@ const currentUsers = computed(() => {
             <!-- <div
               w-68
             >
-              <MultiSelect
+              <MultiSelectEnhanced
                 :options="memberOptions"
                 :selected-options="memberSelectedItems"
                 placeholder="Member"

--- a/packages/apps/board/src/styles/vue-search-select-dark.css
+++ b/packages/apps/board/src/styles/vue-search-select-dark.css
@@ -1,5 +1,16 @@
 /* Vue Search Select Dark Mode Styles */
 
+/* Fix for IME (Chinese input method) width issue - applies to all modes */
+.ui.multiple.search.dropdown > input.search {
+  flex: 1 1 auto !important;
+  transition: width 0.2s ease;
+}
+
+/* Expand input width when composing (Chinese/Japanese/Korean input) */
+.is-composing.ui.multiple.search.dropdown > input.search {
+  width: 96% !important;
+}
+
 /* Dark mode overrides for vue-search-select when html.dark is applied */
 html.dark .ui.dropdown {
   background: var(--global-background);


### PR DESCRIPTION
## Summary

Fixes #88

This PR resolves the issue where the MultiSelect component's input field was too narrow when using Chinese/Japanese/Korean input methods (IME), causing the IME candidate box to display incorrectly.

## Changes

- **Created `MultiSelectEnhanced` component**: Encapsulates IME handling logic with per-instance composition state tracking
- **Dynamic width expansion**: Input field automatically expands from default to 96% width when composing with IME
- **Smooth transitions**: Added CSS transition animation for width changes
- **Refactored FilterModal**: Now uses the new enhanced component for cleaner, more maintainable code
- **Flex layout support**: Input can grow naturally without causing layout issues

## Technical Details

The solution works by:
1. Detecting composition events (`compositionstart`/`compositionend`)
2. Applying an `.is-composing` CSS class when IME is active
3. Dynamically adjusting the input width to provide adequate space for IME candidates
4. Preventing accidental deletion of selected items during IME input using `event.stopPropagation()`

## Testing

Please test with:
- Chinese input methods (Pinyin, Wubi, etc.)
- Japanese input methods
- Korean input methods
- Verify that the input field expands when typing and contracts when IME is closed
- Confirm that selected items are not accidentally deleted when using backspace during IME input

🤖 Generated with [Claude Code](https://claude.ai/code)