### PR TITLE
fix: add onBeforeClose hook to modal components

### DIFF
--- a/packages/apps/board/src/components/board/FilterModal.vue
+++ b/packages/apps/board/src/components/board/FilterModal.vue
@@ -81,6 +81,10 @@ async function onCancel() {
   isHidden.value = true;
 }
 
+async function onBeforeClose() {
+  await onCancel();
+}
+
 const localStorageKeyForFilterOrganizations = getLocalStorageKeyForFilterOrganizations();
 const localStorageKeyForFilterTeams = getLocalStorageKeyForFilterTeams();
 
@@ -99,6 +103,7 @@ function onConfirm() {
     :title="title"
     width="w-200"
     mt="mt-4"
+    @on-before-close="onBeforeClose"
   >
     <div
       w-full

--- a/packages/apps/board/src/components/board/Modal.vue
+++ b/packages/apps/board/src/components/board/Modal.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   mt?: string;
 }>();
 
-const emit = defineEmits(["update:isHidden"]);
+const emit = defineEmits(["update:isHidden", "onBeforeClose"]);
 
 const isHidden = computed({
   get() {
@@ -21,6 +21,7 @@ const isHidden = computed({
 });
 
 function onClose() {
+  emit("onBeforeClose");
   isHidden.value = true;
 }
 

--- a/packages/apps/board/src/components/board/OptionsModal.vue
+++ b/packages/apps/board/src/components/board/OptionsModal.vue
@@ -88,6 +88,10 @@ async function onCancel() {
   isHidden.value = true;
 }
 
+async function onBeforeClose() {
+  await onCancel();
+}
+
 function onConfirm() {
   persistBattleOfGiants();
   isHidden.value = true;
@@ -100,6 +104,7 @@ function onConfirm() {
     :title="title"
     width="w-200"
     mt="mt-4"
+    @on-before-close="onBeforeClose"
   >
     <div
       w-full


### PR DESCRIPTION
## Summary
- Add `onBeforeClose` event to Modal component
- Implement `onBeforeClose` handler in FilterModal to call cancel logic before closing
- Implement `onBeforeClose` handler in OptionsModal to call cancel logic before closing

## Test plan
- [x] Test FilterModal closes properly and cancel logic executes
- [x] Test OptionsModal closes properly and cancel logic executes
- [x] Verify modal state is correctly handled on close

🤖 Generated with [Claude Code](https://claude.ai/code)