### PR TITLE
docs: add CCS utility guide and improve Python README

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,6 +128,7 @@
     "pnpm",
     "prettierrc",
     "problemset",
+    "Pydantic",
     "pytest",
     "shiki",
     "shikijs",

--- a/docs/config.ts
+++ b/docs/config.ts
@@ -6,6 +6,7 @@ const Guides: DefaultTheme.NavItemWithLink[] = [
   { text: "Getting Started", link: "/guide/" },
   { text: "Leaderboard Integration", link: "/guide/board" },
   { text: "Data Format", link: "/guide/data-format" },
+  { text: "CCS Utility", link: "/guide/ccs-utility" },
 ];
 
 const Sponsors: DefaultTheme.NavItemWithLink[] = [

--- a/docs/en/guide/ccs-utility.md
+++ b/docs/en/guide/ccs-utility.md
@@ -1,0 +1,193 @@
+<!-- markdownlint-disable MD024 -->
+
+# CCS Utility
+
+XCPCIO provides two powerful Python CLI tools for working with CCS (Contest Control System) contest data.
+
+## Installation
+
+```bash
+pip install xcpcio
+```
+
+## ccs-archiver
+
+Archive CCS Contest API data to the standard contest package format.
+
+### Basic Usage
+
+```bash
+# Archive to a directory
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o ./output -u admin -p secret
+
+# Archive to a ZIP file
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.zip --token abc123
+
+# Archive to tar.gz
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.tar.gz -u admin -p secret
+
+# Archive to tar.zst (Zstandard compression)
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.tar.zst -u admin -p secret
+```
+
+### Options
+
+| Option             | Short | Description                                            |
+| ------------------ | ----- | ------------------------------------------------------ |
+| `--base-url`       |       | Base URL of the CCS API (required)                     |
+| `--contest-id`     |       | Contest ID to archive (required)                       |
+| `--output`         | `-o`  | Output path: directory or archive file (required)      |
+| `--username`       | `-u`  | HTTP Basic Auth username                               |
+| `--password`       | `-p`  | HTTP Basic Auth password                               |
+| `--token`          | `-t`  | Bearer token for authentication                        |
+| `--no-files`       |       | Skip downloading files                                 |
+| `--no-event-feed`  |       | Skip event-feed dump (large aggregated data)           |
+| `--endpoints`      | `-e`  | Specific endpoints to dump (repeatable)                |
+| `--timeout`        |       | Request timeout in seconds (default: 30)               |
+| `--max-concurrent` |       | Max concurrent requests (default: 10)                  |
+| `--log-level`      |       | Log level: DEBUG, INFO, WARNING, ERROR (default: INFO) |
+| `--verbose`        | `-v`  | Enable verbose logging (same as --log-level DEBUG)     |
+
+### Advanced Usage
+
+**Archive specific endpoints only:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o ./output -u admin -p secret \
+  -e teams -e problems -e submissions
+```
+
+**Skip file downloads for faster archiving:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o contest.zip --no-files -u admin -p secret
+```
+
+**Adjust performance settings:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o ./output -u admin -p secret \
+  --timeout 60 --max-concurrent 20
+```
+
+### Output Formats
+
+The tool supports multiple output formats:
+
+- **Directory**: Uncompressed contest package in a directory structure
+- **ZIP**: Standard ZIP compression (`.zip`)
+- **tar.gz**: Gzip-compressed tarball (`.tar.gz`)
+- **tar.zst**: Zstandard-compressed tarball (`.tar.zst`) - recommended for best compression
+
+When creating an archive file, the tool automatically generates checksums (MD5, SHA1, SHA256, SHA512) for verification.
+
+### Authentication
+
+The tool supports two authentication methods:
+
+1. **HTTP Basic Auth**: Use `--username` and `--password`
+2. **Bearer Token**: Use `--token`
+
+If no authentication is provided, some endpoints may not be accessible.
+
+## contest-api-server
+
+Start a local CCS API server from a contest package.
+
+### Basic Usage
+
+```bash
+# Start server with a contest directory
+contest-api-server -p /path/to/contest
+
+# Start server with an archive file
+contest-api-server -p /path/to/contest.zip
+contest-api-server -p /path/to/contest.tar.gz
+contest-api-server -p /path/to/contest.tar.zst
+```
+
+### Options
+
+| Option              | Short | Description                                                      |
+| ------------------- | ----- | ---------------------------------------------------------------- |
+| `--contest-package` | `-p`  | Contest package directory or archive file (required)             |
+| `--host`            |       | Host to bind to (default: 0.0.0.0)                               |
+| `--port`            |       | Port to bind to (default: 8000)                                  |
+| `--reload`          |       | Enable auto-reload for development                               |
+| `--log-level`       |       | Log level: debug, info, warning, error, critical (default: info) |
+| `--verbose`         | `-v`  | Enable verbose logging (same as --log-level debug)               |
+
+### Advanced Usage
+
+**Custom host and port:**
+
+```bash
+contest-api-server -p /path/to/contest --host 127.0.0.1 --port 9000
+```
+
+**Development mode with auto-reload:**
+
+```bash
+contest-api-server -p /path/to/contest --reload --verbose
+```
+
+**Production deployment:**
+
+```bash
+contest-api-server -p /path/to/contest.tar.zst --host 0.0.0.0 --port 8000
+```
+
+### Supported Archive Formats
+
+The server can directly serve contest data from:
+
+- Uncompressed directories
+- ZIP files (`.zip`)
+- Gzip-compressed tarballs (`.tar.gz`)
+- Zstandard-compressed tarballs (`.tar.zst`)
+
+Archive files are automatically extracted to a temporary directory on startup and cleaned up on exit.
+
+### API Endpoints
+
+Once started, the server provides standard CCS API endpoints:
+
+- `GET /contests` - List contests
+- `GET /contests/{id}` - Get contest details
+- `GET /contests/{id}/teams` - Get teams
+- `GET /contests/{id}/problems` - Get problems
+- `GET /contests/{id}/submissions` - Get submissions
+- And more...
+
+Access the API at `http://localhost:8000` (or your configured host:port).
+
+## Workflow Example
+
+A typical workflow for archiving and serving contest data:
+
+```bash
+# 1. Archive contest data from a live CCS API
+ccs-archiver \
+  --base-url https://contest.example.com/api \
+  --contest-id icpc2024 \
+  -o icpc2024.tar.zst \
+  --token your-api-token
+
+# 2. Start a local API server from the archived data
+contest-api-server -p icpc2024.tar.zst --port 8000
+
+# 3. Access the API at http://localhost:8000
+```
+
+This allows you to:
+
+- Create portable contest data snapshots
+- Serve contest data offline
+- Test and develop against archived contest data
+- Share contest data with others

--- a/docs/zh/config.ts
+++ b/docs/zh/config.ts
@@ -6,6 +6,7 @@ const Guides: DefaultTheme.NavItemWithLink[] = [
   { text: "快速开始", link: "/zh/guide/" },
   { text: "榜单集成", link: "/zh/guide/board" },
   { text: "数据格式", link: "/zh/guide/data-format" },
+  { text: "CCS 工具", link: "/zh/guide/ccs-utility" },
 ];
 
 const Sponsors: DefaultTheme.NavItemWithLink[] = [

--- a/docs/zh/guide/ccs-utility.md
+++ b/docs/zh/guide/ccs-utility.md
@@ -1,0 +1,193 @@
+<!-- markdownlint-disable MD024 -->
+
+# CCS Utility
+
+XCPCIO 提供了两个强大的 Python CLI 工具，用于处理 CCS（Contest Control System）比赛数据。
+
+## 安装
+
+```bash
+pip install xcpcio
+```
+
+## ccs-archiver
+
+将 CCS 比赛 API 数据归档为标准的比赛包格式。
+
+### 基本用法
+
+```bash
+# 归档到目录
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o ./output -u admin -p secret
+
+# 归档为 ZIP 文件
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.zip --token abc123
+
+# 归档为 tar.gz
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.tar.gz -u admin -p secret
+
+# 归档为 tar.zst (Zstandard 压缩)
+ccs-archiver --base-url https://api.example.com/api --contest-id contest123 -o contest.tar.zst -u admin -p secret
+```
+
+### 选项
+
+| 选项               | 简写 | 描述                                               |
+| ------------------ | ---- | -------------------------------------------------- |
+| `--base-url`       |      | CCS API 的基础 URL (必需)                          |
+| `--contest-id`     |      | 要归档的比赛 ID (必需)                             |
+| `--output`         | `-o` | 输出路径：目录或归档文件 (必需)                    |
+| `--username`       | `-u` | HTTP 基本认证用户名                                |
+| `--password`       | `-p` | HTTP 基本认证密码                                  |
+| `--token`          | `-t` | Bearer token 认证                                  |
+| `--no-files`       |      | 跳过文件下载                                       |
+| `--no-event-feed`  |      | 跳过 event-feed 转储 (大型聚合数据)                |
+| `--endpoints`      | `-e` | 指定要转储的端点 (可重复使用)                      |
+| `--timeout`        |      | 请求超时时间（秒）(默认: 30)                       |
+| `--max-concurrent` |      | 最大并发请求数 (默认: 10)                          |
+| `--log-level`      |      | 日志级别: DEBUG, INFO, WARNING, ERROR (默认: INFO) |
+| `--verbose`        | `-v` | 启用详细日志 (等同于 --log-level DEBUG)            |
+
+### 高级用法
+
+**仅归档特定端点:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o ./output -u admin -p secret \
+  -e teams -e problems -e submissions
+```
+
+**跳过文件下载以加快归档速度:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o contest.zip --no-files -u admin -p secret
+```
+
+**调整性能设置:**
+
+```bash
+ccs-archiver --base-url https://api.example.com/api \
+  --contest-id contest123 \
+  -o ./output -u admin -p secret \
+  --timeout 60 --max-concurrent 20
+```
+
+### 输出格式
+
+工具支持多种输出格式:
+
+- **目录**: 未压缩的目录结构比赛包
+- **ZIP**: 标准 ZIP 压缩 (`.zip`)
+- **tar.gz**: Gzip 压缩的 tarball (`.tar.gz`)
+- **tar.zst**: Zstandard 压缩的 tarball (`.tar.zst`) - 推荐使用，压缩率最佳
+
+创建归档文件时，工具会自动生成校验和（MD5、SHA1、SHA256、SHA512）用于验证。
+
+### 身份认证
+
+工具支持两种认证方式:
+
+1. **HTTP 基本认证**: 使用 `--username` 和 `--password`
+2. **Bearer Token**: 使用 `--token`
+
+如果不提供认证信息，某些端点可能无法访问。
+
+## contest-api-server
+
+从比赛包启动本地 CCS API 服务器。
+
+### 基本用法
+
+```bash
+# 使用比赛目录启动服务器
+contest-api-server -p /path/to/contest
+
+# 使用归档文件启动服务器
+contest-api-server -p /path/to/contest.zip
+contest-api-server -p /path/to/contest.tar.gz
+contest-api-server -p /path/to/contest.tar.zst
+```
+
+### 选项
+
+| 选项                | 简写 | 描述                                                         |
+| ------------------- | ---- | ------------------------------------------------------------ |
+| `--contest-package` | `-p` | 比赛包目录或归档文件 (必需)                                  |
+| `--host`            |      | 绑定的主机地址 (默认: 0.0.0.0)                               |
+| `--port`            |      | 绑定的端口 (默认: 8000)                                      |
+| `--reload`          |      | 启用自动重载（开发模式）                                     |
+| `--log-level`       |      | 日志级别: debug, info, warning, error, critical (默认: info) |
+| `--verbose`         | `-v` | 启用详细日志 (等同于 --log-level debug)                      |
+
+### 高级用法
+
+**自定义主机和端口:**
+
+```bash
+contest-api-server -p /path/to/contest --host 127.0.0.1 --port 9000
+```
+
+**开发模式（自动重载）:**
+
+```bash
+contest-api-server -p /path/to/contest --reload --verbose
+```
+
+**生产环境部署:**
+
+```bash
+contest-api-server -p /path/to/contest.tar.zst --host 0.0.0.0 --port 8000
+```
+
+### 支持的归档格式
+
+服务器可以直接从以下格式提供比赛数据服务:
+
+- 未压缩的目录
+- ZIP 文件 (`.zip`)
+- Gzip 压缩的 tarball (`.tar.gz`)
+- Zstandard 压缩的 tarball (`.tar.zst`)
+
+归档文件会在启动时自动解压到临时目录，退出时自动清理。
+
+### API 端点
+
+启动后，服务器提供标准的 CCS API 端点:
+
+- `GET /contests` - 列出比赛
+- `GET /contests/{id}` - 获取比赛详情
+- `GET /contests/{id}/teams` - 获取队伍信息
+- `GET /contests/{id}/problems` - 获取题目信息
+- `GET /contests/{id}/submissions` - 获取提交记录
+- 以及更多...
+
+通过 `http://localhost:8000` 访问 API（或您配置的 host:port）。
+
+## 工作流示例
+
+归档和提供比赛数据的典型工作流:
+
+```bash
+# 1. 从实时 CCS API 归档比赛数据
+ccs-archiver \
+  --base-url https://contest.example.com/api \
+  --contest-id icpc2024 \
+  -o icpc2024.tar.zst \
+  --token your-api-token
+
+# 2. 从归档数据启动本地 API 服务器
+contest-api-server -p icpc2024.tar.zst --port 8000
+
+# 3. 通过 http://localhost:8000 访问 API
+```
+
+这使您可以:
+
+- 创建可移植的比赛数据快照
+- 离线提供比赛数据服务
+- 针对归档的比赛数据进行测试和开发
+- 与他人共享比赛数据

--- a/python/README.md
+++ b/python/README.md
@@ -1,1 +1,56 @@
 # xcpcio-python
+
+Python library and CLI tools for XCPCIO.
+
+## Features
+
+- **Type Definitions**: Pydantic models for contest data structures (teams, submissions, problems, etc.)
+- **Constants**: Shared constants for submission statuses, time units, and penalty calculations
+- **CCS Archiver**: CLI tool to archive CCS API data to contest package format
+- **Contest API Server**: CLI tool to serve contest packages via CCS API
+- **Cross-Language Compatibility**: Mirrors TypeScript types for data consistency
+
+## Installation
+
+```bash
+pip install xcpcio
+```
+
+Or install with [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv add xcpcio
+```
+
+## Development
+
+### Setup
+
+```bash
+# Clone repository
+git clone https://github.com/xcpcio/xcpcio.git
+cd xcpcio/python
+
+# Install dependencies with uv
+uv sync
+```
+
+### Testing
+
+```bash
+# Run tests
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/test_types.py
+```
+
+## Documentation
+
+For detailed documentation, visit:
+
+- [CCS Utility Guide](https://xcpcio.com/guide/ccs-utility)
+
+## License
+
+MIT License &copy; 2020-PRESENT [Dup4](https://github.com/Dup4)


### PR DESCRIPTION
## Summary

- Added comprehensive CCS utility documentation in both English and Chinese
- Enhanced Python README with installation guide and usage instructions
- Updated documentation navigation to include the new CCS utility guide
- Added Pydantic to VS Code spell checker dictionary

## Changes

- `docs/en/guide/ccs-utility.md`: English documentation for CCS archiver and contest-api-server tools
- `docs/zh/guide/ccs-utility.md`: Chinese documentation for CCS utilities
- `docs/config.ts` & `docs/zh/config.ts`: Added navigation links to CCS utility guide
- `python/README.md`: Comprehensive README with features, installation, development, and documentation links
- `.vscode/settings.json`: Added "Pydantic" to cSpell word dictionary

🤖 Generated with [Claude Code](https://claude.ai/code)