### PR TITLE
docs: update license attribution and README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ This project is made possible by all the sponsors supporting my work:
 
 ## License
 
-[MIT](./LICENSE) License &copy; 2020-PRESENT [Dup4](https://github.com/Dup4)
+[MIT](./LICENSE) License &copy; 2020-PRESENT [XCPCIO][xcpcio]
 
+[xcpcio]: https://xcpcio.com
 [gh-release-badge]: https://img.shields.io/github/release/xcpcio/xcpcio.svg
 [gh-release]: https://GitHub.com/xcpcio/xcpcio/releases/
 [license-image-mit]: https://img.shields.io/badge/license-MIT-blue.svg?labelColor=333333

--- a/packages/apps/board/README.md
+++ b/packages/apps/board/README.md
@@ -12,21 +12,6 @@
 ## Preview
 
 - [board.xcpcio.com](https://board.xcpcio.com)
-- [board-xcpcio.vercel.app](https://board-xcpcio.vercel.app/)
-
-## Development
-
-```bash
-# Installation dependencies
-pnpm install
-
-# Run the development server
-pnpm dev
-```
-
-## License
-
-[MIT](../../../LICENSE) License © 2020 - PRESENT [XCPCIO][xcpcio]
 
 ## :clap: Our Supporters
 
@@ -56,7 +41,11 @@ This project is made possible by all the sponsors supporting my work:
   </a>
 </p>
 
-[xcpcio]: https://github.com/xcpcio
+## License
+
+[MIT](../../../LICENSE) License &copy; 2020 - PRESENT [XCPCIO][xcpcio]
+
+[xcpcio]: https://xcpcio.com
 [gh-release-badge]: https://img.shields.io/github/release/xcpcio/xcpcio.svg
 [gh-release]: https://GitHub.com/xcpcio/xcpcio/releases/
 [license-image-mit]: https://img.shields.io/badge/license-MIT-blue.svg?labelColor=333333

--- a/packages/libs/core/README.md
+++ b/packages/libs/core/README.md
@@ -9,10 +9,6 @@
 ![Repo Size](https://img.shields.io/github/repo-size/xcpcio/xcpcio.svg)
 [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@xcpcio/board-app/badge)](https://www.jsdelivr.com/package/npm/@xcpcio/board-app)
 
-## License
-
-[MIT](../../../LICENSE) License © 2020 - PRESENT [XCPCIO][xcpcio]
-
 ## :clap: Our Supporters
 
 ### &#8627; Sponsors
@@ -40,6 +36,10 @@ This project is made possible by all the sponsors supporting my work:
     />
   </a>
 </p>
+
+## License
+
+[MIT](../../../LICENSE) License &copy; 2020 - PRESENT [XCPCIO][xcpcio]
 
 [xcpcio]: https://github.com/xcpcio
 [gh-release-badge]: https://img.shields.io/github/release/xcpcio/xcpcio.svg

--- a/packages/libs/types/README.md
+++ b/packages/libs/types/README.md
@@ -9,10 +9,6 @@
 ![Repo Size](https://img.shields.io/github/repo-size/xcpcio/xcpcio.svg)
 [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@xcpcio/board-app/badge)](https://www.jsdelivr.com/package/npm/@xcpcio/board-app)
 
-## License
-
-[MIT](./LICENSE) License © 2020 - PRESENT [XCPCIO][xcpcio]
-
 ## :clap: Our Supporters
 
 ### &#8627; Sponsors
@@ -41,7 +37,11 @@ This project is made possible by all the sponsors supporting my work:
   </a>
 </p>
 
-[xcpcio]: https://github.com/xcpcio
+## License
+
+[MIT](../../../LICENSE) License &copy; 2020 - PRESENT [XCPCIO][xcpcio]
+
+[xcpcio]: https://xcpcio.com
 [gh-release-badge]: https://img.shields.io/github/release/xcpcio/xcpcio.svg
 [gh-release]: https://GitHub.com/xcpcio/xcpcio/releases/
 [license-image-mit]: https://img.shields.io/badge/license-MIT-blue.svg?labelColor=333333

--- a/python/README.md
+++ b/python/README.md
@@ -53,4 +53,6 @@ For detailed documentation, visit:
 
 ## License
 
-MIT License &copy; 2020-PRESENT [Dup4](https://github.com/Dup4)
+[MIT](../LICENSE) License &copy; 2020 - PRESENT [XCPCIO][xcpcio]
+
+[xcpcio]: https://xcpcio.com


### PR DESCRIPTION
## Summary

- Update copyright holder from individual to XCPCIO organization
- Standardize license attribution format across all README files  
- Update XCPCIO link to point to xcpcio.com website
- Reorder sections to place License after Supporters section
- Remove redundant development instructions from board app README
