### PR TITLE
chore: fix banner load from absolute path

### DIFF
--- a/packages/libs/core/src/image.ts
+++ b/packages/libs/core/src/image.ts
@@ -10,7 +10,7 @@ export function getImageSource(image: Image, asset_host?: string): string {
       return image.url;
     }
 
-    return `${asset_host}/${image.url}`;
+    return new URL(image.url, asset_host === "/" ? window.location.host : asset_host).toString();
   }
 
   if (image?.base64) {


### PR DESCRIPTION
|path|banner|before|after|
|-|-|-|-|
|`/some/page`|`/foo/bar.jpg`|`/some/page//foo/bar.jpg`|`/foo/bar.jpg`|
|`/some/page/`|`/foo/bar.jpg`|`/some/page///foo/bar.jpg`|`/foo/bar.jpg`|
|`/some/page`|`foo/bar.jpg`|`/some/page/foo/bar.jpg`|`/some/foo/bar.jpg`|
|`/some/page/`|`foo/bar.jpg`|`/some/page//foo/bar.jpg`|`/some/page/foo/bar.jpg`|




BREAKING:

some previous data uses `../foo/bar` and need to change to `foo/bar` accordingly. （e.g. icpc/49th/world-finals)