### PR TITLE
fix: Leave the siteCitation field blank in ICPC Standings

### DIFF
--- a/packages/libs/core/src/export/icpc-standings-csv.ts
+++ b/packages/libs/core/src/export/icpc-standings-csv.ts
@@ -42,7 +42,7 @@ export class ICPCStandingsCsvConverter {
         problemsSolved: team.solvedProblemNum,
         totalTime: team.penaltyToMinute,
         lastProblemTime: team.lastSolvedProblemStatistics?.solvedTimestampToMinute ?? 0,
-        siteCitation: rank.contest.name.getOrDefault(),
+        siteCitation: "",
         citation: ordinal(team.rank),
         teamName: team.name.getOrDefault(),
         institution: team.organization?.name.getOrDefault() ?? "",


### PR DESCRIPTION
- Fix #486 