### PR TITLE
feat: add SSL verification control for CLICS tools

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "pyyaml>=6.0.0",
   "semver>=3.0.0",
   "tenacity>=8.0.0",
+  "truststore>=0.10",
   "fastapi>=0.117.1",
   "uvicorn>=0.36.0",
   "zstandard>=0.25.0",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1298,6 +1298,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typeguard"
 version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1407,6 +1416,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "semver" },
     { name = "tenacity" },
+    { name = "truststore" },
     { name = "uvicorn" },
     { name = "zstandard" },
 ]
@@ -1429,6 +1439,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "semver", specifier = ">=3.0.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
+    { name = "truststore", specifier = ">=0.10" },
     { name = "uvicorn", specifier = ">=0.36.0" },
     { name = "zstandard", specifier = ">=0.25.0" },
 ]

--- a/python/xcpcio/app/clics_archiver.py
+++ b/python/xcpcio/app/clics_archiver.py
@@ -72,6 +72,12 @@ def calculate_checksums(file_path: Path) -> dict:
     help="Log level",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging (same as --log-level DEBUG)")
+@click.option("--no-verify-ssl", is_flag=True, help="Disable SSL certificate verification for CLICS API")
+@click.option(
+    "--ssl-ca-cert",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to a CA certificate file for SSL verification",
+)
 def main(
     base_url: str,
     contest_id: str,
@@ -86,6 +92,8 @@ def main(
     max_concurrent: int,
     log_level: str,
     verbose: bool,
+    no_verify_ssl: bool,
+    ssl_ca_cert: Optional[Path],
 ):
     """
     Archive CCS Contest API data to contest package format.
@@ -163,6 +171,8 @@ def main(
         timeout=timeout,
         max_concurrent=max_concurrent,
         include_event_feed=not no_event_feed,
+        ssl_verify=not no_verify_ssl,
+        ssl_ca_cert=ssl_ca_cert,
     )
 
     click.echo(f"Archiving contest '{contest_id}' from {base_url}")

--- a/python/xcpcio/app/clics_uploader.py
+++ b/python/xcpcio/app/clics_uploader.py
@@ -38,6 +38,12 @@ def setup_logging(level: str = "INFO"):
     help="Log level",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging (same as --log-level DEBUG)")
+@click.option("--no-verify-ssl", is_flag=True, help="Disable SSL certificate verification for CLICS API")
+@click.option(
+    "--ssl-ca-cert",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to a CA certificate file for SSL verification",
+)
 def main(
     base_url: str,
     contest_id: str,
@@ -51,6 +57,8 @@ def main(
     interval: int,
     log_level: str,
     verbose: bool,
+    no_verify_ssl: bool,
+    ssl_ca_cert: Optional[Path],
 ):
     """
     Upload CLICS Contest API data to XCPCIO with polling support.
@@ -80,6 +88,8 @@ def main(
         max_concurrent=max_concurrent,
         poll_interval=interval,
         version=__version__,
+        ssl_verify=not no_verify_ssl,
+        ssl_ca_cert=ssl_ca_cert,
     )
 
     click.echo(f"Fetching contest '{contest_id}' from {base_url}")

--- a/python/xcpcio/clics/clics_api_client.py
+++ b/python/xcpcio/clics/clics_api_client.py
@@ -8,6 +8,7 @@ https://ccs-specs.icpc.io/2023-06/contest_api
 
 import asyncio
 import logging
+import ssl
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -38,6 +39,8 @@ class ClicsApiConfig:
     credentials: APICredentials
     timeout: int = 30
     max_concurrent: int = 10
+    ssl_verify: bool = True
+    ssl_ca_cert: Optional[Path] = None
 
 
 class ClicsApiClient:
@@ -71,6 +74,24 @@ class ClicsApiClient:
         """Async context manager exit"""
         await self.close_session()
 
+    def _build_connector(self) -> Optional[aiohttp.TCPConnector]:
+        """Build TCP connector with SSL configuration"""
+        if not self._config.ssl_verify:
+            return aiohttp.TCPConnector(ssl=False)
+
+        if self._config.ssl_ca_cert:
+            ssl_ctx = ssl.create_default_context(cafile=str(self._config.ssl_ca_cert))
+            return aiohttp.TCPConnector(ssl=ssl_ctx)
+
+        try:
+            import truststore
+
+            ssl_ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            return aiohttp.TCPConnector(ssl=ssl_ctx)
+        except ImportError:
+            logger.debug("truststore not available, using default SSL context")
+            return None
+
     async def start_session(self):
         """Initialize the HTTP session with authentication"""
         auth = None
@@ -81,7 +102,7 @@ class ClicsApiClient:
         elif self._config.credentials.token:
             headers["Authorization"] = f"Bearer {self._config.credentials.token}"
 
-        self._session = aiohttp.ClientSession(auth=auth, headers=headers)
+        self._session = aiohttp.ClientSession(auth=auth, headers=headers, connector=self._build_connector())
 
     async def close_session(self):
         """Close the HTTP session"""
@@ -189,7 +210,9 @@ class ClicsApiClient:
             logger.debug(f"Fetched {len(content)} bytes from {file_url}")
             return content
 
-    async def fetch_file_content(self, file_url: Optional[str], override_timeout: Optional[int] = None) -> Optional[bytes]:
+    async def fetch_file_content(
+        self, file_url: Optional[str], override_timeout: Optional[int] = None
+    ) -> Optional[bytes]:
         """Fetch file content as bytes from URL"""
         if not file_url:
             return None

--- a/python/xcpcio/clics/contest_archiver.py
+++ b/python/xcpcio/clics/contest_archiver.py
@@ -36,6 +36,8 @@ class ArchiveConfig:
     timeout: int = 30
     max_concurrent: int = 10
     include_event_feed: bool = False
+    ssl_verify: bool = True
+    ssl_ca_cert: Optional[Path] = None
 
     def to_api_config(self) -> ClicsApiConfig:
         """Convert to ClicsApiConfig"""
@@ -44,6 +46,8 @@ class ArchiveConfig:
             credentials=self.credentials,
             timeout=self.timeout,
             max_concurrent=self.max_concurrent,
+            ssl_verify=self.ssl_verify,
+            ssl_ca_cert=self.ssl_ca_cert,
         )
 
 

--- a/python/xcpcio/clics/contest_uploader.py
+++ b/python/xcpcio/clics/contest_uploader.py
@@ -129,6 +129,8 @@ class UploaderConfig:
     max_concurrent: int = 10
     poll_interval: int = 5
     version: Optional[str] = None
+    ssl_verify: bool = True
+    ssl_ca_cert: Optional[Path] = None
 
     def to_clics_api_config(self) -> ClicsApiConfig:
         return ClicsApiConfig(
@@ -136,6 +138,8 @@ class UploaderConfig:
             credentials=self.clics_credentials,
             timeout=self.timeout,
             max_concurrent=self.max_concurrent,
+            ssl_verify=self.ssl_verify,
+            ssl_ca_cert=self.ssl_ca_cert,
         )
 
 


### PR DESCRIPTION
- Add --no-verify-ssl and --ssl-ca-cert CLI options to clics-uploader and clics-archiver
- Add truststore dependency to trust system root certificates from Python venv
- Pass SSL config through ClicsApiConfig -> UploaderConfig/ArchiveConfig -> CLI